### PR TITLE
Re-ordering and small typographical fixes

### DIFF
--- a/source/firms.rst
+++ b/source/firms.rst
@@ -8,13 +8,13 @@ Explore Firms
 
 Explore Firms contains all the firm entries organized by ID. For each entry, the firm list shows the :ref:`ID <firm-field-id>`, :ref:`Name <firm-field-name>`, :ref:`Street address <firm-field-street-address>`, :ref:`City (Country) <firm-field-city>`, :ref:`Start date <firm-field-start-date>`, :ref:`End date <firm-field-end-date>`.
 
-Firm entry fields
-^^^^^^^^^^^^^^^^^
+Firm Fields
+-------------
 
 .. _firm-field-id:
 
 ID
-  Unique ID number for this entry
+  Unique ID number for this entry.
 
 .. _firm-field-name:
 
@@ -49,11 +49,11 @@ End date
 .. _firm-field-titles:
 
 Titles
-  List of all titles associated with this firm, including the :ref:`firm role <firm-field-roles>`, `title <titles.html#title-field-title>`_, `author <titles.html#title-field-author>`_, and `date published <titles.html#title-field-date-of-publication>`_.
+  List of all titles associated with this firm, including the :ref:`firm role <firm-field-roles>`, `title <titles.html#title-field-title>`_, `author <persons.html#person-contributor-author>`_, and `date published <titles.html#title-field-date-of-publication>`_.
 
 .. _firm-field-export-citation-list:
 
-Export citation list
+Export Citation List
 	Export a list of all titles associated with the firm in MLA, APA, Chicago, and BibTex. Select tabs to change format. 
 
 .. _firm-field-suggestions-and-comments:
@@ -93,9 +93,6 @@ Search Firms
 -------------
 
 Search Firms page defaults to a basic firm search by name with a custom search page available via the Advanced Search button. Select a method to sort results with the Results Sorted By dropdown menu. Advanced Search allows users to search for a specific firm by fields associated with a firm.
-
-Firm Search parameters
-^^^^^^^^^^^^^^^^^^^^^^
 
 .. _firm-search-name:
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,14 +6,13 @@
 Welcome to Women's Print History Project's documentation!
 =========================================================
 
-User Manual
+User Guide
 -----------
 
 .. toctree::
    :maxdepth: 2
    
    intro
-   getting_started
    titles
    persons
    firms

--- a/source/intro.rst
+++ b/source/intro.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-The Women’s Print History Project 1750-1836 (WPHP) is the first comprehensive bibliographical database of women's contributions to print for one of the most convulsive periods in the history of both women’s writing and print. The database, with nearly 2,000 person entries and over 8,000 title entries, will enable rigorous quantitative analysis of patterns in women's print history.
+The Women’s Print History Project, 1750-1830 is a comprehensive bibliographical database of women’s contributions to print for one of the most convulsive periods in both women’s and print history. We collect detailed information about books that women were involved in producing, not just as authors, but also as printers, publishers, booksellers, editors, compilers, translators, engravers, illustrators, and composers. In addition to detailed bibliographical information about the material components of the book, we record basic data about the people and firms that produced them, allowing us to trace the networks and relationships that structured the book trades.
 
 This application was developed by the `Digital Humanities Innovation Lab`_ at `Simon Fraser University`_ with considerable assistance and support from the `SFU Library`_.
 

--- a/source/persons.rst
+++ b/source/persons.rst
@@ -10,8 +10,10 @@ Explore Persons
 
 The person list contains all the person entries organized alphabetically by last name. Select ID to sort by ID number. For each entry, the person list shows the :ref:`ID <person-field-id>`, :ref:`Last name <person-field-last-name>`, :ref:`First name <person-field-first-name>`, :ref:`Gender <person-field-gender>`, :ref:`Date of birth <person-field-date-of-birth>`, and :ref:`Date of death <person-field-date-of-death>`.
 
-Person fields
-^^^^^^^^^^^^^
+.. _persons-field-label:
+
+Person Fields
+--------------
 
 .. _person-field-id:
 
@@ -60,12 +62,12 @@ Place of death
 
 .. _person-field-viaf-entry:
 
-VIAF Entry
+VIAF URI
   Link to the person’s Virtual International Authority File if available.
 
 .. _person-field-wikipedia-entry:
 
-Wikipedia Entry
+Wikipedia URL
   Link to the person’s entry in Wikipedia if available.
 
 .. _person-field-image-url:
@@ -157,14 +159,13 @@ Translator
   The person who is responsible for translating the text from one language to another.
 
 
-Person Search
+.. _persons-search-label:
+
+Search Persons
 --------------
 
 
 The Search Persons page defaults to a basic person search by name with a custom search page available via the Advanced Search button. Select a method to sort results with the Results Sorted By dropdown menu. The Advanced Search allows users to search for specific persons by fields associated with a person. Search results return all person entries that include the search term. Selecting a person will return all titles associated with that person. 
-
-Person Search parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. _person-search-name:
 

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -2,7 +2,7 @@
 
 {% block sidebartoc %}
 
-<h3><a href="https://dhil.lib.sfu.ca/wphp">Women's Print History Project</a></h3>
+<h3><a href="https://dhil.lib.sfu.ca/wphp">Women’s Print History Project</a></h3>
 <ul>
   <li><a href="https://dhil.lib.sfu.ca/wphp">Main Site</a></li>
   <li><a href="https://womensprinthistoryproject.wordpress.com//">Wordpress Blog</a></li>

--- a/source/titles.rst
+++ b/source/titles.rst
@@ -10,142 +10,9 @@ Explore Titles
 
 Explore titles contains all the title entries organized by ID. For each title, the title list shows the :ref:`Title ID <title-field-id>`, :ref:`Title <title-field-title>`, :ref:`Contributor (Roles) <title-field-contributors>`, :ref:`Firms (Firm Role) <title-field-firms>`, :ref:`Date <title-field-date-of-publication>`, and :ref:`Edition <title-field-edition>`.
 
-.. _titles-search-label:
+.. _title-fields-label:
 
-Search Titles
--------------
-
-The Title Search page defaults to a basic title search function with a Results Sorted By field and an Advanced Search button. 
-
-
-.. _titles-search-title:
-
-Title
-  Text search for all or part of a :ref:`title <title-field-title>`.
-
-.. _titles-search-results-sorted-by:
-
-Results Sorted By
-  Sort results alphabetically, by :ref:`publication date <title-field-date-of-publication>`, by :ref:`first publication date <title-field-date-of-first-publication>`, and by :ref:`edition number <title-field-edition>`.
-
-.. _titles-search-id:
-
-Title ID
-  Search for a title by entering the exact :ref:`Title ID number <title-field-id>`.
-
-.. _titles-search-filter-person:
-
-Filter by Person
-  Titles can be filtered by all or part of a Person’s name, by gender (female, male, or unknown), and by firm role. 
-
-.. _titles-search-signed-author:
-
-Signed author
-  Text search for title by :ref:`Signed author field <title-field-signed-author>`
-
-.. _titles-search-pseudonym:
-
-Pseudonym
-  Text search for title by :ref:`Pseudonym field <title-field-pseudonym>`
-
-.. _titles-search-filter-firm:
-
-Filter by Firm
-  Titles can be filtered by all of part of a `Firm’s name <firms.html#firm-field-name>`_, by `Firm gender (female, male, unknown) <firms.html#firm-field-gender>`_, by `Firm role (Publisher, Printer, Bookseller, Unknown) <firms.html#explore-firm-roles>`_, and by `Firm Address <firms.html#firm-field-street-address>`_.  
-
-.. _titles-search-self-published:
-
-Self-Published
-	Search by whether a title has been :ref:`self-published <title-field-self-published>` or not. 
-
-.. _titles-search-volumes:
-
-Volumes
-	Search for a title by entering the exact :ref:`number of volumes <title-field-volumes>`.
-
-.. _titles-search-date-of-publication:
-
-Date of Publication
-  Search for the year a :ref:`title was published <title-field-date-of-publication>` (e.g. 1795) or a range of years (1790-1800) or partial range of years (``*``-1800).
-
-.. _titles-search-date-of-first-publication:
-
-Date of First Publication
-  Search for the year a title was :ref:`first published <title-field-date-of-first-publication>` (e.g. 1795) or a range of years (1790-1800) or partial range of years (``*``-1800).
-
-.. _titles-search-edition-number:
-
-Edition Number
-  Search for a title by entering the :ref:`edition number <title-field-edition>`.
-
-.. _titles-search-imprint:
-
-Imprint
-  Text search for title by :ref:`Imprint field <title-field-imprint>`.
-
-.. _titles-search-colophon:
-
-Colophon
-  Text search for title by :ref:`Colophon field <title-field-colophon>`.
-
-.. _titles-search-location-of-printing:
-
-Location of Printing
-  Searches Location of :ref:`Printing field <title-field-location-of-printing>`.
-
-.. _titles-search-format:
-
-Format
-  Titles can be filtered by the :ref:`Format in which they were printed <title-field-format>`.  A description of all formats can be found in `Explore Formats <https://dhil.lib.sfu.ca/wphp/format/>`_. 
-
-.. _titles-search-length:
-
-Length
-  Search for a title by entering the :ref:`length of the page <title-field-length>` in centimetres.
-
-.. _titles-search-width:
-
-Width
-  Search for a title by entering the :ref:`width of the page <title-field-width>` in centimetres. 
-
-.. _titles-search-filter-by-price:
-
-Filter by Price
-  Title search can be filtered by :ref:`Price (pound) field <title-field-price-pound>`, :ref:`Price (shilling) field <title-field-price-shilling>`, and/or :ref:`Price (pence) field <title-field-price-pence>`. Filter search by Equal To (exact), Less Than, or Greater Than the amount entered. 
-
-.. _titles-search-genre:
-
-Genre
-  Titles can be filtered by the Genres in which they were printed.  A description of all formats can be found in `Explore Genres <https://dhil.lib.sfu.ca/wphp/genre/>`_. 
-
-.. _titles-search-shelfmark:
-
-Shelfmark
-  Search for title by entering the :ref:`Shelfmark <title-field-shelfmarks>`.
-
-.. _titles-search-notes:
-
-Notes
-	Search by the :ref:`Notes field <title-field-notes>`. 
-
-.. _titles-search-hand-verified:
-
-Hand-Verified
-  Title search can be filtered by titles which have been :ref:`Hand-Verified <title-field-hand-verified>` by clicking Yes, or not Hand-Verified by clicking No. The default setting of None removes the filter. 
-
-.. _titles-search-verified:
-
-Verified
-  Title search can be filtered by titles which have been :ref:`Verified <title-field-verified>` by clicking Yes, or not Verified by clicking No. The default setting of None removes the filter. 
-
-.. _titles-search-attempted-verification:
-
-Attempted Verification
-  Title search can be filtered by texts which have had an :ref:`Attempted Verification <title-field-attempted-verification>` by clicking Yes, or no attempted Verification by clicking No. The default setting of None removes the filter.
-
-Search results appear below the search fields. The search can be reset using the reset button. A list of the entries generated by the search can be exported using the export button. Results can be exported with MLA, Chicago, APA formatting or as a BibTex file. Search results include the :ref:`Title ID <title-field-id>`, :ref:`Title <title-field-title>`, :ref:`Contributors (Role) <title-field-contributors>`, :ref:`Firms (Role) <title-field-firms>`, :ref:`Date of Publication <title-field-date-of-publication>`, :ref:`Edition <title-field-edition>`.
-
-Title fields
+Title Fields
 ------------
 
 .. _title-field-id:
@@ -161,7 +28,7 @@ Title
 .. _title-field-contributors:
 
 Contributors
-  Linked to `Persons <persons.html#person-list>`_. `Contribution roles <https://dhil.lib.sfu.ca/wphp/role/>`_ include name of author(s) (if known) and, where appropriate, editors, translators, authors of introductory material, engravers, and women involved in printing, publishing, bookselling, etc. If any of the roles are attributed to a woman whose name is unknown, they will be listed as “Unknown.”
+  Linked to `Persons <persons.html#person-list>`_. `Contributor roles <https://dhil.lib.sfu.ca/wphp/role/>`_ include name of author(s) (if known) and, where appropriate, editors, translators, authors of introductory material, engravers, and women involved in printing, publishing, bookselling, etc. If any of the roles are attributed to a woman whose name is unknown, they will be listed as “Unknown.”
 
 .. _title-field-signed-author:
 
@@ -277,7 +144,7 @@ Genre
 .. _title-field-sources:
 
 Sources
-  List of sources consulted to populate the entry fields. Sources include the source name and ID. The source ID will vary according to the source, but will correspond to a unique identifier for the source consulted. For descriptions of sources, see `Explore Sources <https://dhil.lib.sfu.ca/wphp/sources/>`_. Selecting the source name will open a page with information about that source and a list of titles that use that source. If the source ID is hyperlinked, selecting it will take you to the original source record.
+  List of sources consulted to populate the entry fields. Sources include the source name and ID. The source ID will vary according to the source, but will correspond to a unique identifier for the source consulted. For descriptions of sources, see `Explore Sources <https://dhil.lib.sfu.ca/wphp/source/>`_. Selecting the source name will open a page with information about that source and a list of titles that use that source. If the source ID is hyperlinked, selecting it will take you to the original source record.
 
 
 .. _title-field-shelfmarks:
@@ -314,3 +181,139 @@ Bibliographic Entry
 
 Suggestions and Comments
   To make a suggestion or comment on a title entry, select Suggestions and Comments and fill out the form. Use this form to make suggested revisions or additions to the title record. 
+
+
+.. _titles-search-label:
+
+Search Titles
+-------------
+
+The Title Search page defaults to a basic title search function with a Results Sorted By field and an Advanced Search button. 
+
+
+.. _titles-search-title:
+
+Title
+  Text search for all or part of a :ref:`title <title-field-title>`.
+
+.. _titles-search-results-sorted-by:
+
+Results Sorted By
+  Sort results alphabetically, by :ref:`publication date <title-field-date-of-publication>`, by :ref:`first publication date <title-field-date-of-first-publication>`, and by :ref:`edition number <title-field-edition>`.
+
+.. _titles-search-id:
+
+Title ID
+  Search for a title by entering the exact :ref:`Title ID number <title-field-id>`.
+
+.. _titles-search-filter-person:
+
+Filter by Person
+  Titles can be filtered by all or part of a Person’s name, by gender (female, male, or unknown), and by firm role. 
+
+.. _titles-search-signed-author:
+
+Signed author
+  Text search for title by :ref:`Signed author field <title-field-signed-author>`.
+
+.. _titles-search-pseudonym:
+
+Pseudonym
+  Text search for title by :ref:`Pseudonym field <title-field-pseudonym>`.
+
+.. _titles-search-filter-firm:
+
+Filter by Firm
+  Titles can be filtered by all of part of a `Firm’s name <firms.html#firm-field-name>`_, by `Firm gender (female, male, unknown) <firms.html#firm-field-gender>`_, by `Firm role (Publisher, Printer, Bookseller, Unknown) <firms.html#explore-firm-roles>`_, and by `Firm Address <firms.html#firm-field-street-address>`_.  
+
+.. _titles-search-self-published:
+
+Self-Published
+	Search by whether a title has been :ref:`self-published <title-field-self-published>` or not. 
+
+.. _titles-search-volumes:
+
+Volumes
+	Search for a title by entering the exact :ref:`number of volumes <title-field-volumes>`.
+
+.. _titles-search-date-of-publication:
+
+Date of Publication
+  Search for the year a :ref:`title was published <title-field-date-of-publication>` (e.g. 1795) or a range of years (1790-1800) or partial range of years (``*``-1800).
+
+.. _titles-search-date-of-first-publication:
+
+Date of First Publication
+  Search for the year a title was :ref:`first published <title-field-date-of-first-publication>` (e.g. 1795) or a range of years (1790-1800) or partial range of years (``*``-1800).
+
+.. _titles-search-edition-number:
+
+Edition Number
+  Search for a title by entering the :ref:`edition number <title-field-edition>`.
+
+.. _titles-search-imprint:
+
+Imprint
+  Text search for title by :ref:`Imprint field <title-field-imprint>`.
+
+.. _titles-search-colophon:
+
+Colophon
+  Text search for title by :ref:`Colophon field <title-field-colophon>`.
+
+.. _titles-search-location-of-printing:
+
+Location of Printing
+  Searches Location of :ref:`Printing field <title-field-location-of-printing>`.
+
+.. _titles-search-format:
+
+Format
+  Titles can be filtered by the :ref:`Format in which they were printed <title-field-format>`.  A description of all formats can be found in `Explore Formats <https://dhil.lib.sfu.ca/wphp/format/>`_. 
+
+.. _titles-search-length:
+
+Length
+  Search for a title by entering the :ref:`length of the page <title-field-length>` in centimetres.
+
+.. _titles-search-width:
+
+Width
+  Search for a title by entering the :ref:`width of the page <title-field-width>` in centimetres. 
+
+.. _titles-search-filter-by-price:
+
+Filter by Price
+  Title search can be filtered by :ref:`Price (pound) field <title-field-price-pound>`, :ref:`Price (shilling) field <title-field-price-shilling>`, and/or :ref:`Price (pence) field <title-field-price-pence>`. Filter search by Equal To (exact), Less Than, or Greater Than the amount entered. 
+
+.. _titles-search-genre:
+
+Genre
+  Titles can be filtered by the Genres in which they were printed.  A description of all formats can be found in `Explore Genres <https://dhil.lib.sfu.ca/wphp/genre/>`_. 
+
+.. _titles-search-shelfmark:
+
+Shelfmark
+  Search for title by entering the :ref:`Shelfmark <title-field-shelfmarks>`.
+
+.. _titles-search-notes:
+
+Notes
+	Search by the :ref:`Notes field <title-field-notes>`. 
+
+.. _titles-search-hand-verified:
+
+Hand-Verified
+  Title search can be filtered by titles which have been :ref:`Hand-Verified <title-field-hand-verified>` by clicking Yes, or not Hand-Verified by clicking No. The default setting of None removes the filter. 
+
+.. _titles-search-verified:
+
+Verified
+  Title search can be filtered by titles which have been :ref:`Verified <title-field-verified>` by clicking Yes, or not Verified by clicking No. The default setting of None removes the filter. 
+
+.. _titles-search-attempted-verification:
+
+Attempted Verification
+  Title search can be filtered by texts which have had an :ref:`Attempted Verification <title-field-attempted-verification>` by clicking Yes, or no attempted Verification by clicking No. The default setting of None removes the filter.
+
+Search results appear below the search fields. The search can be reset using the reset button. A list of the entries generated by the search can be exported using the export button. Results can be exported with MLA, Chicago, APA formatting or as a BibTex file. Search results include the :ref:`Title ID <title-field-id>`, :ref:`Title <title-field-title>`, :ref:`Contributors (Role) <title-field-contributors>`, :ref:`Firms (Role) <title-field-firms>`, :ref:`Date of Publication <title-field-date-of-publication>`, :ref:`Edition <title-field-edition>`.


### PR DESCRIPTION
These fixes follow the suggested edits from ML following today's mtg (see Google Drive for notes). Most of the changes are minor, including slight re-ordering, promoting some subdivisions to divisions, and editorial standardization (periods after all field descriptions, for instance).

More major changes include: User Manual is now User _Guide_and we have nixed Getting Started from the TOC, effectively removing it from the documentation. 